### PR TITLE
feat: update viem to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "async-retry": "^1.3.3",
     "eip1193-types": "^0.2.1",
     "p-limit": "^3.1.0",
-    "viem": "^0.3.37"
+    "viem": "^1.0.2"
   },
   "devDependencies": {
     "@sxzz/eslint-config": "3.0.0-beta.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       viem:
-        specifier: ^0.3.37
-        version: 0.3.37(typescript@5.0.4)
+        specifier: ^1.0.2
+        version: 1.0.2(typescript@5.0.4)
     devDependencies:
       '@sxzz/eslint-config':
         specifier: 3.0.0-beta.11
@@ -87,7 +87,7 @@ importers:
         version: 5.0.4
       unocss:
         specifier: ^0.52.3
-        version: 0.52.3(postcss@8.4.23)(vite@4.3.8)
+        version: 0.52.3(postcss@8.4.24)(vite@4.3.8)
       vite:
         specifier: ^4.3.8
         version: 4.3.8(@types/node@20.2.3)
@@ -826,7 +826,7 @@ packages:
       sirv: 2.0.3
     dev: true
 
-  /@unocss/postcss@0.52.3(postcss@8.4.23):
+  /@unocss/postcss@0.52.3(postcss@8.4.24):
     resolution: {integrity: sha512-n3SdpSsn0MpWB9Pf6JjzR7U2rsA6jkD5QPJttIL9yxrK9i4KXTwGNio/4iM2Rs4x+qAzLtNjIBJ1xdxtIFA3kA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -837,7 +837,7 @@ packages:
       css-tree: 2.3.1
       fast-glob: 3.2.12
       magic-string: 0.30.0
-      postcss: 8.4.23
+      postcss: 8.4.24
     dev: true
 
   /@unocss/preset-attributify@0.52.3:
@@ -1150,24 +1150,12 @@ packages:
       - vue
     dev: true
 
-  /@wagmi/chains@0.3.1(typescript@5.0.4):
-    resolution: {integrity: sha512-NN5qziBLFeXnx0+3ywdiKKXUSW4H73Wc1jRrygl9GKXVPawU0GBMudwXUfV7VOu6E9vmG7Arj0pVsEwq63b2Ew==}
-    peerDependencies:
-      typescript: '>=4.9.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.0.4
-    dev: false
-
-  /abitype@0.8.2(typescript@5.0.4):
-    resolution: {integrity: sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==}
+  /@wagmi/chains@1.1.0(typescript@5.0.4):
+    resolution: {integrity: sha512-pWZlxBk0Ql8E7DV8DwqlbBpOyUdaG9UDlQPBxJNALuEK1I0tbQ3AVvSDnlsEIt06UPmPo5o27gzs3hwPQ/A+UA==}
     peerDependencies:
       typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
     peerDependenciesMeta:
-      zod:
+      typescript:
         optional: true
     dependencies:
       typescript: 5.0.4
@@ -1184,6 +1172,18 @@ packages:
     dependencies:
       typescript: 5.0.4
     dev: true
+
+  /abitype@0.8.7(typescript@5.0.4):
+    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.0.4
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3327,6 +3327,15 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss@8.4.24:
+    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3944,7 +3953,7 @@ packages:
       '@types/unist': 2.0.6
     dev: true
 
-  /unocss@0.52.3(postcss@8.4.23)(vite@4.3.8):
+  /unocss@0.52.3(postcss@8.4.24)(vite@4.3.8):
     resolution: {integrity: sha512-BgL3kbxwt839t0ojo/j+i8xU4qu+fyV34SJOMQuFhLu6xkPNepvr6uPeipzNDajR7EZP3Q+jXJT9AWLKLLg1jw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3957,7 +3966,7 @@ packages:
       '@unocss/cli': 0.52.3
       '@unocss/core': 0.52.3
       '@unocss/extractor-arbitrary-variants': 0.52.3
-      '@unocss/postcss': 0.52.3(postcss@8.4.23)
+      '@unocss/postcss': 0.52.3(postcss@8.4.24)
       '@unocss/preset-attributify': 0.52.3
       '@unocss/preset-icons': 0.52.3
       '@unocss/preset-mini': 0.52.3
@@ -4009,16 +4018,16 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /viem@0.3.37(typescript@5.0.4):
-    resolution: {integrity: sha512-17jycP/1Hy9DsDpHlaaI7bbAHBDYGfVYHN6j0ltE7A/S30RXhPVFe4LAPRfmG+xR2QBq8xSUpjO78cRgDLBjZQ==}
+  /viem@1.0.2(typescript@5.0.4):
+    resolution: {integrity: sha512-3Bn+CuInU8zsdKqqzFDWL018x4B9HDjPIISztReGcBjikY+04tP7CrQQCf1lbinK3wWrEoFU9VDiptCciNjUQA==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
-      '@wagmi/chains': 0.3.1(typescript@5.0.4)
-      abitype: 0.8.2(typescript@5.0.4)
+      '@wagmi/chains': 1.1.0(typescript@5.0.4)
+      abitype: 0.8.7(typescript@5.0.4)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       ws: 8.12.0
     transitivePeerDependencies:


### PR DESCRIPTION
Update viem to 1.0.2

## Question
Should we keep the previous partial decode behavior in `decodeEventLog` or let it throw error when not conform to the ABI 

https://viem.sh/docs/migration-guide.html#minor-decodeeventlog-behavior-change