### PR TITLE
ci: deploy docs action ignore v0 tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*'
+      - '!v0.*'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Tigger release action without docs action on v0 tags push event